### PR TITLE
Mobile Version, Runic Font, Backspace Fix

### DIFF
--- a/hungarian.html
+++ b/hungarian.html
@@ -21,17 +21,24 @@
                     <p>Guess the 5-letter Hungarian word in 6 tries:</p>
                 </header>
                 <div id="game-board"></div>
-                <button id="reset-btn" class="reset-btn">Reset Game</button>
+                <div class="buttons"><button id="reset-btn" class="reset-btn">Reset Game</button></div>
                 <footer>
-                    <div id="color-info"></div>
-                    <div id="wordle-info"></div>
+                    <details>
+                        <summary>Keyboard:</summary>
+                        <div id="keyboard" class="keyboard"></div>
+                    </details>
+                    <details>
+                        <summary>How to Use:</summary>
+                        <div id="color-info"></div>
+                        <div id="wordle-info"></div>
+                    </details>
                 </footer>
             </div>
         </div>
         <div class="main-content column-right">
             <div class="content-card">
                 <details>
-                    <summary>Show possible words (Spoiler):</summary>
+                    <summary>Show Possible Words (Spoiler):</summary>
                     <div id="word-list"></div>
                 </details>
             </div>

--- a/javanese.html
+++ b/javanese.html
@@ -21,17 +21,24 @@
                     <p>Guess the 5-letter Javanese word in 6 tries:</p>
                 </header>
                 <div id="game-board"></div>
-                <button id="reset-btn" class="reset-btn">Reset Game</button>
+                <div class="buttons"><button id="reset-btn" class="reset-btn">Reset Game</button></div>
                 <footer>
-                    <div id="color-info"></div>
-                    <div id="wordle-info"></div>
+                    <details>
+                        <summary>Keyboard:</summary>
+                        <div id="keyboard" class="keyboard"></div>
+                    </details>
+                    <details>
+                        <summary>How to Use:</summary>
+                        <div id="color-info"></div>
+                        <div id="wordle-info"></div>
+                    </details>
                 </footer>
             </div>
         </div>
         <div class="main-content column-right">
             <div class="content-card">
                 <details>
-                    <summary>Show possible words (Spoiler):</summary>
+                    <summary>Show Possible Words (Spoiler):</summary>
                     <div id="word-list"></div>
                 </details>
             </div>

--- a/script/wordle-base.js
+++ b/script/wordle-base.js
@@ -44,6 +44,7 @@ export class WordleEngine {
             this.addWordleInfo(this.isSolverMode);
             this.addResetButton();
             this.resetGame();
+            this.addKeyboard();
         } catch (e) {
             console.error(`Could not load ${this.fileName}`, e);
         }
@@ -113,6 +114,7 @@ export class WordleEngine {
                 this.activeRow--;
                 this.currentGuessTokens = [...this.guessesTokens[this.activeRow]];
                 this.guessesTokens[this.activeRow] = Array(5).fill("");
+                this.currentGuessTokens.pop();
                 
                 this.updatePossibleWords();
             }
@@ -268,6 +270,39 @@ export class WordleEngine {
         // limit the number of suggestions to avoid overwhelming the user
         const limit = 200;
         wordlister(this.langFolder, candidates, limit);
+    }
+
+    // creates an on-screen keyboard for phone users
+    addKeyboard() {
+        const keyboard = document.getElementById('keyboard');
+        if (!keyboard) return;
+        keyboard.innerHTML = '';
+
+        // blueprint for how the keys should appear on screen
+        const bindings = [
+            [ "ö", "ü", "ő", "ű", "ó", "ú", "Backspace", "Enter" ],
+            [ "q", "w", "e", "r", "t", "z", "u", "i", "o", "p" ],
+            [ "a", "s", "d", "f", "g", "h", "j", "k", "l", "é" ],
+            [ "í", "y", "x", "c", "v", "b", "n", "m", "á" ]
+        ]
+
+        // creates the keyboard HTML and adds eventListeners that link to handleKey
+        bindings.forEach((keyrow) => {
+            const row = document.createElement('div');
+            row.className = "key-row";
+            keyrow.forEach((key) => {
+                const button = document.createElement('button');
+                button.className = "key-box";
+                button.innerHTML = key;
+                const buttonInput = { "key": key };
+                button.addEventListener('pointerdown', (e) => {
+                    this.handleKey(buttonInput);
+                    button.blur();
+                });
+                row.appendChild(button);
+            });
+            keyboard.appendChild(row);
+        });
     }
 
     // adds informational text about the game and language specifics to the page

--- a/solver.html
+++ b/solver.html
@@ -21,20 +21,25 @@
                     <p>Click boxes to set feedback colors, then see possible words.</p>
                 </header>
                 <div id="game-board"></div>
-                <button id="reset-btn" class="reset-btn">Reset Solver</button>
+                <div class="buttons"><button id="reset-btn" class="reset-btn">Reset Game</button></div>
                 <footer>
-                    <div id="color-info"></div>
-                    <div id="wordle-info"></div>
+                    <details>
+                        <summary>Keyboard:</summary>
+                        <div id="keyboard" class="keyboard"></div>
+                    </details>
+                    <details>
+                        <summary>How to Use:</summary>
+                        <div id="color-info"></div>
+                        <div id="wordle-info"></div>
+                    </details>
                 </footer>
             </div>
         </div>
         <div class="main-content column-right">
             <div class="content-card">
                 <details>
-                    <summary>Show possible words:</summary>
-                    <div id="word-list">
-                        <p>Loading dictionary...</p>
-                    </div>
+                    <summary>Show Possible Words:</summary>
+                    <div id="word-list"></div>
                 </details>
             </div>
         </div>

--- a/style/style.css
+++ b/style/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Old+Hungarian&display=swap');
+
 :root {
     --bg-color: #f4f7f6;
     --card-bg: #ffffff;
@@ -7,7 +9,7 @@
 }
 
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-family: 'Segoe UI', 'Noto Sans Old Hungarian', Tahoma, Geneva, Verdana, sans-serif;
     margin: 0;
     padding: 0;
     background-color: var(--bg-color);
@@ -42,7 +44,6 @@ summary {
 
 .columns { 
     display: flex;
-    gap: 10px;
     justify-content: center;
     align-items: flex-start;
 }
@@ -91,7 +92,7 @@ button.reset-btn:hover {
     background: var(--card-bg);
     width: 100%;
     max-width: 800px;
-    padding: 20px 20px 20px 40px;
+    padding: 20px;
     border-radius: 12px;
     box-shadow: 0 10px 25px rgba(0,0,0,0.1);
     border-left: 8px solid var(--hu-color);
@@ -133,6 +134,7 @@ button.reset-btn:hover {
     text-transform: uppercase;
     vertical-align: top;
     box-sizing: border-box;
+    user-select: none;
 }
 .white-text { color: white; }
 .white { background: #ffffff; }
@@ -163,4 +165,29 @@ button.reset-btn:hover {
     list-style: none;
     padding: 0;
     font-size: 1.1rem;
+}
+
+.keyboard {
+    padding-bottom: 10px;
+}
+.key-row {
+    display: flex;
+    justify-content: center;
+}
+.key-box {
+    text-transform: uppercase;
+    background-color: var(--bg-color);
+    cursor: pointer;
+    margin: 2px;
+    padding-left: 16px;
+    padding-right: 16px;
+}
+
+@media only screen and (max-width:1300px) {
+    .columns { 
+        display: block;
+        width: 100%;
+    }
+    .column-left { max-width: 100%; }
+    .column-right { max-width: 100%; }
 }


### PR DESCRIPTION
Closes #22 
Closes #21
Closes #20

Adds fonts for Old Hungarian Runic.
Centers the "Reset Game/Reset Solver" button.
Capitalized summaries for collapsibles.
Wordle grid boxes are no longer accidentally highlightable.

On smaller screens, multi-column pages appear as single column.
Added a screen keyboard.

Fixed bug in Solver Mode, when a Backspace doesn't correctly jump to a previous row.